### PR TITLE
RDKEMW-4903: Optimize AppArmor Profile Load

### DIFF
--- a/apparmor_parse.sh
+++ b/apparmor_parse.sh
@@ -55,10 +55,6 @@ while read line; do
                              complain_list+=("$PROFILES_DIR/$profile")
                      elif [ "$blocklist_mode" != "disable" ]; then
                              enforce_list+=("$PROFILES_DIR/$profile")
-                     elif [ "$blocklist_mode" == "disable" ]; then
-                           if [ "$process" != "global" ]; then
-                           unconfined_list+=("$PROFILES_UNCONFINED_DIR/$profile")
-                           fi
                      fi
              elif [ "$mode" == "complain" ] && [ "$blocklist_mode" != "disable" ]; then
                  other_list+=("$PROFILES_DIR/$profile")


### PR DESCRIPTION
Optimize the apparmor_parser.sh script for loading the Apparmor profiles.

Reason for change: Loading Apparmor profiles efficiently during boot-up.
Test Procedure: Ensure profiles are loading in expected mode.
Risks: low

Signed-off-by: ldonth501 <LasyaPrakarsha_DonthiVenkata@comcast.com>