### PR TITLE
RDKEMW-7586: Converting Apparmor text profiles to binary for performance optimization

### DIFF
--- a/apparmor_parse.sh
+++ b/apparmor_parse.sh
@@ -82,17 +82,20 @@ while IFS=: read -r process mode; do
   eval "blocklist_mode=\${block_modes_${process//./_}}"
   if [[ -z $blocklist_mode ]]; then
      blocklist_mode=$mode                        
-  fi                
-        
-  if [[ $mode == "complain" || $blocklist_mode == "complain" ]]; then
-    profile_file_complain="/etc/apparmor.d/*$process"
-    complain_list+=("$profile_file_complain") 
-                                                                    
-  elif [[ $mode == "enforce" && $blocklist_mode != "disable" ]]; then
-    profile_file_enforce="$PROFILES_DIR/*$process"
-    enforce_list+=("$profile_file_enforce")
-  fi                    
-             
+  fi
+  
+  if [ "$mode" == "enforce" ]; then
+        if [ "$blocklist_mode" == "complain" ]; then
+              profile_file_complain="/etc/apparmor.d/*$process"
+              complain_list+=("$profile_file_complain")
+        elif [ "$blocklist_mode" != "disable" ]; then
+               profile_file_enforce="$PROFILES_DIR/*$process"
+               enforce_list+=("$profile_file_enforce")
+        fi
+  elif [ "$mode" == "complain" ] && [ "$blocklist_mode" != "disable" ]; then
+           profile_file_complain="/etc/apparmor.d/*$process"
+           complain_list+=("$profile_file_complain")
+  fi                                 
 done < "$Apparmor_defaults"
 
 if [[ ${#complain_list[@]} -gt 0 ]]; then


### PR DESCRIPTION
Reason for change: Covert and install the apparmor profiles in binary format
Test Procedure: build and test
Risks: None
Priority: P1