### PR TITLE
RDKMVE-1752: Update apparmor default profile in rdkcentral repo

### DIFF
--- a/apparmor_parse.sh
+++ b/apparmor_parse.sh
@@ -21,11 +21,11 @@
 
 Apparmor_defaults="/etc/apparmor/apparmor_defaults"
 Apparmor_blocklist="/opt/secure/Apparmor_blocklist"
-PROFILES_DIR="/etc/apparmor.d/"
+PROFILES_DIR="/etc/apparmor/binprofiles/*/"
 PARSER="/sbin/apparmor_parser"
 SYSFS_AA_PATH="/sys/kernel/security/apparmor/profiles"
 RDKLOGS="/opt/logs/startup_stdout_log.txt"
-profile_binary=false
+profile_binary=true
 
 if [ -f /lib/rdk/apparmor_utils.sh ]; then
     source /lib/rdk/apparmor_utils.sh

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -13,7 +13,7 @@ profile default /** flags=(attach_disconnected){
   /{,**} pix,
   change_profile -> **,
   # Deny some sensitive files of /sys
-  deny /sys/f[^is]*/** wklx,
+  deny /sys/f[^is]*/** wkl,
   deny /sys/fs/[^c]*/** wklx,
   deny /sys/fs/c[^g]*/** wklx,
   deny /sys/fs/cg[^r]*/** wklx,
@@ -25,6 +25,6 @@ profile default /** flags=(attach_disconnected){
   deny /proc/sys/kernel/{?,??,s[^yh]**,s[yh][^ms]**,sys[^r]**,sysr[^q]**,p[^a]**,pa[^n]**,pan[^i]**,pani[^c]**,c[^o]**,co[^r]**,cor[^e]**,[^spc]**} w,
   deny /proc/sysrq-trigger rwklx,
   deny /proc/kcore rwklx,
-  deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} wklx,
-  deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} wklx,
+  deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} wkl,
+  deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} wkl,
 }

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -18,7 +18,6 @@ profile default /** flags=(attach_disconnected){
   deny /sys/fs/c[^g]*/** wklx,
   deny /sys/fs/cg[^r]*/** wklx,
   deny /sys/firmware/** wklx,
-  deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} w,
   # Deny some sensitive files from /proc fs.
   deny /proc/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -22,7 +22,6 @@ profile default /** flags=(attach_disconnected){
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny /proc/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9/]*}/** w,
   #deny everything except shm* and core* in /proc/sys/kernel/
-  deny /proc/sys/kernel/{?,??,s[^h]**,sh[^m]**,c[^o]**,co[^r]**,cor[^e]**,[^sc]**} w,
   deny /proc/sysrq-trigger rwklx,
   deny /proc/kcore rwklx,
 }

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -13,11 +13,10 @@ profile default /** flags=(attach_disconnected){
   /{,**} pix,
   change_profile -> **,
   # Deny some sensitive files of /sys
-  deny /sys/f[^s]*/** wklx,
+  deny /sys/f[^is*]/** wklx,
   deny /sys/fs/[^c]*/** wklx,
   deny /sys/fs/c[^g]*/** wklx,
   deny /sys/fs/cg[^r]*/** wklx,
-  deny /sys/firmware/** wklx,
   # Deny some sensitive files from /proc fs.
   deny /proc/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -13,11 +13,11 @@ profile default /** flags=(attach_disconnected){
   /{,**} pix,
   change_profile -> **,
   # Deny some sensitive files of /sys
-  deny /sys/f[^is]*/** w,
-  deny /sys/fs/[^c]*/** w,
-  deny /sys/fs/c[^g]*/** w,
-  deny /sys/fs/cg[^r]*/** w,
-  deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} w,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** wklx,
   deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} w,
   # Deny some sensitive files from /proc fs.
   deny /proc/* w,   # deny write for all files directly in /proc (not in a subdir)

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -26,4 +26,5 @@ profile default /** flags=(attach_disconnected){
   deny /proc/kcore rwklx,
   deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} wklx,
   deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend_mode?**,[^s]**} wklx,
+  /sys/firmware/brcmstb/suspend_mode rw,
 }

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -24,4 +24,6 @@ profile default /** flags=(attach_disconnected){
   #deny everything except shm* and core* in /proc/sys/kernel/
   deny /proc/sysrq-trigger rwklx,
   deny /proc/kcore rwklx,
+  deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} wklx,
+  deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend_mode?**,[^s]**} wklx,
 }

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -22,9 +22,9 @@ profile default /** flags=(attach_disconnected){
   # deny write to files not in /proc/<number>/** or /proc/sys/**
   deny /proc/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9/]*}/** w,
   #deny everything except shm* and core* in /proc/sys/kernel/
+  deny /proc/sys/kernel/{?,??,s[^yh]**,s[yh][^ms]**,sys[^r]**,sysr[^q]**,p[^a]**,pa[^n]**,pan[^i]**,pani[^c]**,c[^o]**,co[^r]**,cor[^e]**,[^spc]**} w,
   deny /proc/sysrq-trigger rwklx,
   deny /proc/kcore rwklx,
   deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} wklx,
   deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} wklx,
-  /sys/firmware/brcmstb/suspend_mode rw,
 }

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -13,7 +13,7 @@ profile default /** flags=(attach_disconnected){
   /{,**} pix,
   change_profile -> **,
   # Deny some sensitive files of /sys
-  deny /sys/f[^is*]/** wklx,
+  deny /sys/f[^is]*/** wklx,
   deny /sys/fs/[^c]*/** wklx,
   deny /sys/fs/c[^g]*/** wklx,
   deny /sys/fs/cg[^r]*/** wklx,
@@ -25,6 +25,6 @@ profile default /** flags=(attach_disconnected){
   deny /proc/sysrq-trigger rwklx,
   deny /proc/kcore rwklx,
   deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} wklx,
-  deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend_mode?**,[^s]**} wklx,
+  deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} wklx,
   /sys/firmware/brcmstb/suspend_mode rw,
 }

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -13,12 +13,12 @@ profile default /** flags=(attach_disconnected){
   /{,**} pix,
   change_profile -> **,
   # Deny some sensitive files of /sys
-  deny /sys/f[^is]*/** wkl,
+  deny /sys/f[^is]*/** w,
   deny /sys/fs/[^c]*/** wklx,
   deny /sys/fs/c[^g]*/** wklx,
   deny /sys/fs/cg[^r]*/** wklx,
-  deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} wl,
-  deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} wl,
+  deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} w,
+  deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} w,
   # Deny some sensitive files from /proc fs.
   deny /proc/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -17,6 +17,8 @@ profile default /** flags=(attach_disconnected){
   deny /sys/fs/[^c]*/** wklx,
   deny /sys/fs/c[^g]*/** wklx,
   deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} wl,
+  deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} wl,
   # Deny some sensitive files from /proc fs.
   deny /proc/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
@@ -25,6 +27,4 @@ profile default /** flags=(attach_disconnected){
   deny /proc/sys/kernel/{?,??,s[^yh]**,s[yh][^ms]**,sys[^r]**,sysr[^q]**,p[^a]**,pa[^n]**,pan[^i]**,pani[^c]**,c[^o]**,co[^r]**,cor[^e]**,[^spc]**} w,
   deny /proc/sysrq-trigger rwklx,
   deny /proc/kcore rwklx,
-  deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} wkl,
-  deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} wkl,
 }

--- a/generic_profiles/default
+++ b/generic_profiles/default
@@ -14,9 +14,9 @@ profile default /** flags=(attach_disconnected){
   change_profile -> **,
   # Deny some sensitive files of /sys
   deny /sys/f[^is]*/** w,
-  deny /sys/fs/[^c]*/** wklx,
-  deny /sys/fs/c[^g]*/** wklx,
-  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/fs/[^c]*/** w,
+  deny /sys/fs/c[^g]*/** w,
+  deny /sys/fs/cg[^r]*/** w,
   deny /sys/firmware/{b[^r]**,br[^c]**,brc[^m]**,brcm[^s]**,brcms[^t]**,brcmst[^b]**,[^b]**} w,
   deny /sys/firmware/brcmstb/{s[^u]**,su[^s]**,sus[^p]**,susp[^e]**,suspe[^n]**,suspen[^d]**,suspend[^_]**,suspend_[^m]**,suspend_m[^o]**,suspend_mo[^d]**,suspend_mod[^e]**,suspend_mode?**,[^s]**} w,
   # Deny some sensitive files from /proc fs.


### PR DESCRIPTION
In broadcom apparmor.service prevents application to change the file, sysfs_set_string returned an error so the system didn't enter s2/s3, which block the feature